### PR TITLE
Add kline analysis container

### DIFF
--- a/.github/workflows/ping_render.yml
+++ b/.github/workflows/ping_render.yml
@@ -1,4 +1,4 @@
-name: Keep Render Service Alive
+name: Ping Local Kline Service
 
 on:
   schedule:
@@ -9,6 +9,6 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Curl Render Health Endpoint
+      - name: Curl Kline Health Endpoint
         run: |
-          curl -s -o /dev/null -w "%{http_code}" https://stock-investment-agent-ai-foundations.onrender.com/healthz
+          curl -s -o /dev/null -w "%{http_code}" http://localhost:10000/healthz

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Stock_Investment_Agent-AI_Foundations_Capstone_Project-_2025
+# Stock Investment Agent
+
+This project provides a set of Docker services for running the stock investment
+analysis demo locally.
+
+## Running locally
+
+Use `docker-compose` to build and start all services:
+
+```bash
+docker-compose up --build
+```
+
+The following services will be available:
+
+- **app** – main Gradio interface on [http://localhost:7860](http://localhost:7860)
+- **monitor** – API backend on [http://localhost:5001](http://localhost:5001)
+- **kline** – K-line analysis service on [http://localhost:10000](http://localhost:10000)
+
+The previous Render deployment is no longer required; the `kline` container is
+built from `flow/k_line_analysis/` and exposed on port `10000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,22 @@ services:
         source: ./app/config
         target: /app/config
 
+  kline:
+    build:
+      context: ./flow/k_line_analysis
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:10000:10000"
+    environment:
+      PORT: 10000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:10000/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
 # 修改网络配置（Windows 专用）
 networks:
   default:

--- a/flow/k_line_analysis/Dockerfile
+++ b/flow/k_line_analysis/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+ENV TZ=Asia/Shanghai \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 10000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "10000"]

--- a/flow/k_line_analysis/render.yaml
+++ b/flow/k_line_analysis/render.yaml
@@ -1,3 +1,4 @@
+# Deprecated Render configuration. The service is now built locally via Docker Compose.
 services:
   - type: web
     name: k_line_analysis


### PR DESCRIPTION
## Summary
- add Dockerfile for kline analysis
- expose new `kline` service from docker-compose
- deprecate Render config and update workflow to ping local container
- document running all containers locally

## Testing
- `python -m py_compile flow/k_line_analysis/main.py`
- *(docker-compose not available)*

------
https://chatgpt.com/codex/tasks/task_e_685571f202648322947105c3e91826dd